### PR TITLE
Export `ConfigError` type.

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -6,7 +6,7 @@ import pkg from './package.json';
 
 export default {
   external: [...builtinModules, ...Object.keys(pkg.dependencies)],
-  input: 'src/loadConfig.js',
+  input: 'src/index.js',
   output: {file: pkg.main, format: 'cjs', sourcemap: true},
   plugins: [
     flow({

--- a/src/ConfigError.js
+++ b/src/ConfigError.js
@@ -1,11 +1,11 @@
 // @flow
-import type {ConfigResult} from './types';
+import type {Config, ConfigMap} from './types';
 
-export default class ConfigError<Config: ConfigResult<any>> extends Error {
-  config: Config;
+export default class ConfigError<CMap: ConfigMap> extends Error {
+  config: Config<CMap>;
   errors: Array<Error>;
 
-  constructor(config: Config, errors: Array<Error>) {
+  constructor(config: Config<CMap>, errors: Array<Error>) {
     super('Configuration could not be loaded.');
     this.config = config;
     this.errors = errors;

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,4 @@
+// @flow
+export {default} from './loadConfig';
+export type {default as ConfigError} from './ConfigError';
+export type {Config} from './types';

--- a/src/loadConfig.js
+++ b/src/loadConfig.js
@@ -7,10 +7,7 @@ import objectMap from 'object.map';
 import pProps from 'p-props';
 import ConfigError from './ConfigError';
 import loadGroup from './loadGroup';
-import type {ConfigGroup, ConfigMap} from './types';
-
-type ExtractConfig = <GMap: ConfigGroup>(GMap) => $ObjMap<GMap, () => ?string>;
-export type Config<CMap: ConfigMap> = $ObjMap<CMap, ExtractConfig>;
+import type {Config, ConfigMap} from './types';
 
 export default function loadConfig<CMap: ConfigMap>(
   configMap: CMap,

--- a/src/types.js
+++ b/src/types.js
@@ -1,6 +1,11 @@
 // @flow
 /* eslint-disable no-use-before-define */
 
+export type Config<CMap: ConfigMap> = $ObjMap<
+  CMap,
+  <GMap: ConfigGroup>(GMap) => $ObjMap<GMap, () => ?string>,
+>;
+
 export type ConfigGroup = {
   [key: string]: string | EnvironmentConfig | FileConfig,
 };
@@ -9,8 +14,8 @@ export type ConfigMap = {
   [group: string]: ConfigGroup,
 };
 
-export type ConfigResult<Config> = {
-  config: Config,
+export type ConfigResult<CMap: ConfigMap> = {
+  config: Config<CMap>,
   error?: Error,
 };
 


### PR DESCRIPTION
```
import loadConfig, {type Config, type ConfigError} from 'env-and-files';

const config = {
  groupOne: {
    propOne: 'ENV_NAME',
  },
};

loadConfig(config).catch((error: ConfigError<typeof config>) => {
  // Do something with the error.
});
```