### PR TITLE
Let `loadConfig` take a callback instead of returning a Promise

### DIFF
--- a/src/resolveConfig.js
+++ b/src/resolveConfig.js
@@ -1,0 +1,19 @@
+// @flow
+import arrFlatten from 'arr-flatten';
+import collectionMap from 'collection-map';
+import objectMap from 'object.map';
+import pProps from 'p-props';
+import ConfigError from './ConfigError';
+import type {ConfigCallback, ConfigMap, LoadedConfig} from './types';
+
+export default function resolveConfig<CMap: ConfigMap>(
+  loadedConfig: LoadedConfig<CMap>,
+  callback: ConfigCallback<CMap>,
+) {
+  pProps(loadedConfig).then(result => {
+    const config = objectMap(result, prop => prop.config);
+    const errors = arrFlatten(collectionMap(result, prop => prop.errors));
+    const error = errors.length > 0 ? new ConfigError(config, errors) : null;
+    callback(error, config);
+  });
+}

--- a/src/types.js
+++ b/src/types.js
@@ -1,22 +1,28 @@
 // @flow
 /* eslint-disable no-use-before-define */
+import type ConfigError from './ConfigError';
 
 export type Config<CMap: ConfigMap> = $ObjMap<
   CMap,
   <GMap: ConfigGroup>(GMap) => $ObjMap<GMap, () => ?string>,
 >;
 
+export type ConfigCallback<CMap: ConfigMap> = (
+  error: ?ConfigError<CMap>,
+  config: Config<CMap>,
+) => void;
+
 export type ConfigGroup = {
-  [key: string]: string | EnvironmentConfig | FileConfig,
+  [property: string]: string | EnvironmentConfig | FileConfig,
 };
 
 export type ConfigMap = {
   [group: string]: ConfigGroup,
 };
 
-export type ConfigResult<CMap: ConfigMap> = {
-  config: Config<CMap>,
-  error?: Error,
+export type ConfigResult = {
+  config: ?string,
+  error: ?Error,
 };
 
 export type EnvironmentConfig = {
@@ -29,3 +35,10 @@ export type FileConfig = {
   filePath: string,
   required?: boolean,
 };
+
+export type LoadedConfig<CMap: ConfigMap> = $ObjMap<
+  CMap,
+  <GMap: ConfigGroup>(
+    GMap,
+  ) => $ObjMap<GMap, () => ConfigResult | Promise<ConfigResult>>,
+>;


### PR DESCRIPTION
```
import loadConfig from 'env-and-files';

const config = {
  groupOne: {
    propOne: {
      required: true,
      variableName: 'ENV_VAR',
    }
  },
};

loadConfig(config, (error, config) => {
  // "config" will always be defined.
  // "error" will only be defined if there's an error.
});

// Promise interface still works.
loadConfig(config).then(
  config => { /* Do something with "config". */ },
  error => { /* Do something with "error". */ },
);
```