### PR TITLE
Remove `config` from `ConfigError`.

### DIFF
--- a/__tests__/loadConfig.test.js
+++ b/__tests__/loadConfig.test.js
@@ -178,12 +178,9 @@ describe('loadConfig', () => {
           );
 
           // $FlowFixMe
-          const error: $ConfigError<any> = await configPromise.catch(
-            err => err,
-          );
+          const error: ConfigError = await configPromise.catch(err => err);
 
           expect(error).toBeInstanceOf(Error);
-          expect(error.config.groupOne.propOne).toBeNull();
           expect(error.message).toEqual('Configuration could not be loaded.');
 
           const {errors} = error;
@@ -331,10 +328,9 @@ describe('loadConfig', () => {
             'Configuration could not be loaded.',
           );
           // $FlowFixMe
-          const error: ConfigError<any> = await configPromise.catch(err => err);
+          const error: ConfigError = await configPromise.catch(err => err);
 
           expect(error).toBeInstanceOf(Error);
-          expect(error.config.groupOne.propOne).toBeNull();
           expect(error.message).toEqual('Configuration could not be loaded.');
 
           const {errors} = error;

--- a/src/ConfigError.js
+++ b/src/ConfigError.js
@@ -1,13 +1,9 @@
 // @flow
-import type {Config, ConfigMap} from './types';
-
-export default class ConfigError<CMap: ConfigMap> extends Error {
-  config: Config<CMap>;
+export default class ConfigError extends Error {
   errors: Array<Error>;
 
-  constructor(config: Config<CMap>, errors: Array<Error>) {
+  constructor(errors: Array<Error>) {
     super('Configuration could not be loaded.');
-    this.config = config;
     this.errors = errors;
     this.message = 'Configuration could not be loaded.';
   }

--- a/src/loadConfig.js
+++ b/src/loadConfig.js
@@ -16,12 +16,12 @@ declare function loadConfig<CMap: ConfigMap>(
 ): Promise<Config<CMap>>;
 declare function loadConfig<CMap: ConfigMap>(
   configMap: CMap,
-  callback: (error: ?ConfigError<CMap>, config: Config<CMap>) => void,
+  callback: (error: ?ConfigError, config: Config<CMap>) => void,
 ): void;
 
 export default function loadConfig<CMap: ConfigMap>(
   configMap: CMap,
-  callback?: (error: ?ConfigError<CMap>, config: Config<CMap>) => void,
+  callback?: (error: ?ConfigError, config: Config<CMap>) => void,
 ) {
   assert(isobject(configMap), '"configMap" must be a ConfigMap object.');
   assert(

--- a/src/resolveConfig.js
+++ b/src/resolveConfig.js
@@ -13,7 +13,7 @@ export default function resolveConfig<CMap: ConfigMap>(
   pProps(loadedConfig).then(result => {
     const config = objectMap(result, prop => prop.config);
     const errors = arrFlatten(collectionMap(result, prop => prop.errors));
-    const error = errors.length > 0 ? new ConfigError(config, errors) : null;
+    const error = errors.length > 0 ? new ConfigError(errors) : null;
     callback(error, config);
   });
 }

--- a/src/types.js
+++ b/src/types.js
@@ -8,7 +8,7 @@ export type Config<CMap: ConfigMap> = $ObjMap<
 >;
 
 export type ConfigCallback<CMap: ConfigMap> = (
-  error: ?ConfigError<CMap>,
+  error: ?ConfigError,
   config: Config<CMap>,
 ) => void;
 


### PR DESCRIPTION
This was a potential security issue.  If `ConfigError` was logged, as expected of an error, potentially sensitive data could be exposed.  To access `config` on error, you'll have to use the callback interface.