### PR TITLE
Only run `release` on master.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,6 +59,9 @@ workflows:
       - lint
       - test
       - release:
+          filters:
+            branches:
+              only: master
           requires:
             - lint
             - test


### PR DESCRIPTION
I should have done this from the start.  Sorry, Circle.