### PR TITLE
Make type imports work.

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "src"
   ],
   "license": "MIT",
-  "main": "dist/loadConfig.js",
+  "main": "dist/index.js",
   "name": "env-and-files",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Since `index.js` wasn't main, Flow couldn't pick up on the exports.