### PR TITLE
Run tests in `node` environment.

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,5 @@
 module.exports = {
   collectCoverageFrom: ['src/**/*.js', '!src/{index,types}.js'],
+  testEnvironment: 'node',
   testMatch: ['**/*.test.js'],
 };


### PR DESCRIPTION
As opposed to the default `jsdom`.