### PR TITLE
Renovate `rollup` config.

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "rimraf": "^2.6.2",
     "rollup": "^0.57.0",
     "rollup-plugin-babel": "^4.0.0-beta.2",
-    "rollup-plugin-flow": "^1.1.1"
+    "rollup-plugin-closure-compiler-js": "^1.0.6",
+    "rollup-plugin-prettier": "^0.4.0"
   },
   "engines": {
     "node": ">=4"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,7 +1,8 @@
 // @flow
 import builtinModules from 'builtin-modules';
 import babel from 'rollup-plugin-babel';
-import flow from 'rollup-plugin-flow';
+import closureCompilerJs from 'rollup-plugin-closure-compiler-js';
+import prettier from 'rollup-plugin-prettier';
 import pkg from './package.json';
 
 export default {
@@ -9,9 +10,17 @@ export default {
   input: 'src/index.js',
   output: {file: pkg.main, format: 'cjs', sourcemap: true},
   plugins: [
-    flow({
-      pretty: true,
-    }),
     babel(),
+    closureCompilerJs({
+      applyInputSourceMaps: false,
+      assumeFunctionWrapper: true,
+      compilationLevel: 'SIMPLE',
+      env: 'CUSTOM',
+      languageOut: 'ECMASCRIPT6_STRICT',
+      processCommonJsModules: false,
+      renaming: false,
+      useTypesForOptimization: false,
+    }),
+    prettier(),
   ],
 };


### PR DESCRIPTION
This is completely unnecessary for this library, but I think it's cool.