### PR TITLE
Loosen `ConfigGroup` type.

### DIFF
--- a/src/types.js
+++ b/src/types.js
@@ -12,9 +12,9 @@ export type ConfigCallback<CMap: ConfigMap> = (
   config: Config<CMap>,
 ) => void;
 
-export type ConfigGroup = {
-  [property: string]: string | EnvironmentConfig | FileConfig,
-};
+export type ConfigGroup = $Subtype<{
+  +[property: string]: string | EnvironmentConfig | FileConfig,
+}>;
 
 export type ConfigMap = {
   [group: string]: ConfigGroup,


### PR DESCRIPTION
This allows stuff like
```
import type {Config, ConfigMap} from 'env-and-files';

type MyConfig<CMap: ConfigMap> = Config<{groupOne: {propOne: string, propTwo: string}, ...CMap}>;
```
to work okay.