### PR TITLE
Allow `ConfigError` to be stringified.

### DIFF
--- a/__tests__/loadConfig.test.js
+++ b/__tests__/loadConfig.test.js
@@ -477,4 +477,19 @@ describe('loadConfig', () => {
       });
     });
   });
+
+  describe('the error returned', () => {
+    it('is serializable.', done => {
+      const variableName = 'PROP_ONE';
+      delete process.env[variableName];
+      loadConfig(
+        {groupOne: {propOne: {required: true, variableName}}},
+        error => {
+          const json = JSON.stringify(error);
+          expect(json).toMatch(`${variableName} is not defined.`);
+          done();
+        },
+      );
+    });
+  });
 });

--- a/src/ConfigError.js
+++ b/src/ConfigError.js
@@ -7,4 +7,13 @@ export default class ConfigError extends Error {
     this.errors = errors;
     this.message = 'Configuration could not be loaded.';
   }
+
+  toJSON() {
+    // Flow complains about not having it this way, for some reason.
+    const errors: Array<string> = this.errors.map(error => error.message);
+    return {
+      errors,
+      message: this.message,
+    };
+  }
 }


### PR DESCRIPTION
Y'know, for `pino`.  Because you should totally log config errors.