### PR TITLE
Don't double assign `message` of `ConfigError`.

### DIFF
--- a/src/ConfigError.js
+++ b/src/ConfigError.js
@@ -5,7 +5,6 @@ export default class ConfigError extends Error {
   constructor(errors: Array<Error>) {
     super('Configuration could not be loaded.');
     this.errors = errors;
-    this.message = 'Configuration could not be loaded.';
   }
 
   toJSON() {


### PR DESCRIPTION
Here, "perf" means "don't push a release just for this".