### PR TITLE
Only iterate through `configMap` once.

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,6 @@
     "name": "Matthew Fernando Garcia"
   },
   "dependencies": {
-    "arr-flatten": "^1.1.0",
-    "collection-map": "^1.0.0",
     "isobject": "^3.0.1",
     "object.map": "^1.0.1",
     "p-props": "^1.2.0"

--- a/src/loadConfigSync.js
+++ b/src/loadConfigSync.js
@@ -1,7 +1,5 @@
 // @flow
-import arrFlatten from 'arr-flatten';
 import assert from 'assert';
-import collectionMap from 'collection-map';
 import isobject from 'isobject';
 import objectMap from 'object.map';
 import ConfigError from './ConfigError';
@@ -12,23 +10,22 @@ export default function loadConfigSync<CMap: ConfigMap>(
   configMap: CMap,
 ): Config<CMap> {
   assert(isobject(configMap), '"configMap" must be a ConfigMap object.');
-  const groups = objectMap(configMap, (group, groupName) => {
+  const errors = [];
+  const result = objectMap(configMap, (group, groupName) => {
     assert(
       isobject(group),
       `"configMap.${groupName}" must be a ConfigGroup object.`,
     );
-    const props = objectMap(group, (prop, propName) =>
-      loadPropertySync(prop, propName, groupName),
-    );
-    return {
-      config: objectMap(props, prop => prop.config),
-      errors: collectionMap(props, prop => prop.error).filter(error => error),
-    };
+    return objectMap(group, (prop, propName) => {
+      const {config, error} = loadPropertySync(prop, propName, groupName);
+      if (error) {
+        errors.push(error);
+      }
+      return config;
+    });
   });
-  const config = objectMap(groups, group => group.config);
-  const errors = arrFlatten(collectionMap(groups, group => group.errors));
   if (errors.length > 0) {
     throw new ConfigError(errors);
   }
-  return config;
+  return result;
 }

--- a/src/loadProperty.js
+++ b/src/loadProperty.js
@@ -2,15 +2,15 @@
 import isobject from 'isobject';
 import loadEnvironmentConfig from './loadEnvironmentConfig';
 import loadFileConfig from './loadFileConfig';
-import type {ConfigResult, EnvironmentConfig, FileConfig} from './types';
+import type {EnvironmentConfig, FileConfig} from './types';
 
 export default function loadProperty(
   property: string | EnvironmentConfig | FileConfig,
   propertyName: string,
   groupName: string,
-): ConfigResult | Promise<ConfigResult> {
+) {
   if (typeof property === 'string') {
-    return loadEnvironmentConfig({variableName: property});
+    return Promise.resolve(loadEnvironmentConfig({variableName: property}));
   }
   const propertyIsObject = isobject(property);
   const isEnvConfig =
@@ -35,7 +35,7 @@ export default function loadProperty(
   }
   return isEnvConfig
     ? // $FlowFixMe
-      loadEnvironmentConfig(property)
+      Promise.resolve(loadEnvironmentConfig(property))
     : // $FlowFixMe
       loadFileConfig(property);
 }


### PR DESCRIPTION
Not a fan of side-effects, but I'm not a fan of iterating through a collection two to three times, either.