### PR TITLE
Don't double-check in `loadEnvironmentConfig`.

### DIFF
--- a/src/loadEnvironmentConfig.js
+++ b/src/loadEnvironmentConfig.js
@@ -3,15 +3,7 @@ import type {EnvironmentConfig} from './types';
 
 export default function loadEnvironmentConfig(property: EnvironmentConfig) {
   const {required = false, variableName} = property;
-
-  // '' is falsey, so `process.env[variableName] || undefined` would not behave right when the variable is set to ''.
-  let config = process.env[variableName];
-
-  // `process.env[variableName] ?? undefined`, on the other hand.
-  if (typeof config !== 'string') {
-    config = undefined;
-  }
-
+  const config = process.env[variableName];
   const error =
     required && typeof config !== 'string'
       ? new Error(`${variableName} is not defined.`)


### PR DESCRIPTION
I think this was leftover from when I used to return `null` for `config`.