### PR TITLE
Refine `flow` types.

### DIFF
--- a/src/ConfigError.js
+++ b/src/ConfigError.js
@@ -7,11 +7,9 @@ export default class ConfigError extends Error {
     this.errors = errors;
   }
 
-  toJSON() {
-    // Flow complains about not having it this way, for some reason.
-    const errors: Array<string> = this.errors.map(error => error.message);
+  toJSON(): {errors: Array<string>, message: string} {
     return {
-      errors,
+      errors: this.errors.map(error => error.message),
       message: this.message,
     };
   }

--- a/src/loadConfigSync.js
+++ b/src/loadConfigSync.js
@@ -17,11 +17,11 @@ export default function loadConfigSync<CMap: ConfigMap>(
       `"configMap.${groupName}" must be a ConfigGroup object.`,
     );
     return objectMap(group, (prop, propName) => {
-      const {config, error} = loadPropertySync(prop, propName, groupName);
-      if (error) {
-        errors.push(error);
+      const property = loadPropertySync(prop, propName, groupName);
+      if (property.error) {
+        errors.push(property.error);
       }
-      return config;
+      return property.config;
     });
   });
   if (errors.length > 0) {

--- a/src/loadEnvironmentConfig.js
+++ b/src/loadEnvironmentConfig.js
@@ -5,9 +5,9 @@ export default function loadEnvironmentConfig(property: EnvironmentConfig) {
   const {required = false, variableName} = property;
   const config = process.env[variableName];
   const error =
-    required && typeof config !== 'string'
-      ? new Error(`${variableName} is not defined.`)
-      : undefined;
+    required &&
+    typeof config !== 'string' &&
+    new Error(`${variableName} is not defined.`);
 
   return {config, error};
 }

--- a/src/loadFileConfig.js
+++ b/src/loadFileConfig.js
@@ -10,7 +10,7 @@ export default function loadFileConfig(property: FileConfig) {
       resolve({
         // config: config ?? undefined,
         config: typeof config === 'string' ? config : undefined,
-        error: error && required ? error : undefined,
+        error: required && error,
       }),
     ),
   );

--- a/src/loadFileConfigSync.js
+++ b/src/loadFileConfigSync.js
@@ -6,8 +6,8 @@ export default function loadFileConfigSync(property: FileConfig) {
   const {encoding = 'utf8', filePath, required = false} = property;
   try {
     const config = readFileSync(filePath, encoding);
-    return {config, error: undefined};
+    return {config};
   } catch (error) {
-    return {config: undefined, error: required ? error : undefined};
+    return {config: undefined, error: required && error};
   }
 }

--- a/src/loadPropertySync.js
+++ b/src/loadPropertySync.js
@@ -3,13 +3,13 @@ import assert from 'assert';
 import isobject from 'isobject';
 import loadEnvironmentConfig from './loadEnvironmentConfig';
 import loadFileConfigSync from './loadFileConfigSync';
-import type {ConfigResult, EnvironmentConfig, FileConfig} from './types';
+import type {EnvironmentConfig, FileConfig} from './types';
 
 export default function loadPropertySync(
   property: string | EnvironmentConfig | FileConfig,
   propertyName: string,
   groupName: string,
-): ConfigResult {
+) {
   if (typeof property === 'string') {
     return loadEnvironmentConfig({variableName: property});
   }

--- a/src/types.js
+++ b/src/types.js
@@ -1,28 +1,23 @@
 // @flow
 /* eslint-disable no-use-before-define */
-import type ConfigError from './ConfigError';
 
 export type Config<CMap: ConfigMap> = $ObjMap<
   CMap,
-  <GMap: ConfigGroup>(GMap) => $ObjMap<GMap, () => string | void>,
+  <GMap: ConfigGroup>(
+    GMap,
+  ) => $ObjMap<
+    GMap,
+    ((string | {required?: false}) => ?string) & (({required: true}) => string),
+  >,
 >;
 
-export type ConfigCallback<CMap: ConfigMap> = (
-  error: ?ConfigError,
-  config: Config<CMap>,
-) => void;
-
-export type ConfigGroup = $Subtype<{
-  +[property: string]: string | EnvironmentConfig | FileConfig,
-}>;
+export type ConfigGroup = {
+  // $FlowFixMe
+  [property: string]: string | EnvironmentConfig | FileConfig,
+};
 
 export type ConfigMap = {
   [group: string]: ConfigGroup,
-};
-
-export type ConfigResult = {
-  config: string | void,
-  error: ?Error,
 };
 
 export type EnvironmentConfig = {|
@@ -35,10 +30,3 @@ export type FileConfig = {|
   filePath: string,
   required?: boolean,
 |};
-
-export type LoadedConfig<CMap: ConfigMap> = $ObjMap<
-  CMap,
-  <GMap: ConfigGroup>(
-    GMap,
-  ) => $ObjMap<GMap, () => ConfigResult | Promise<ConfigResult>>,
->;


### PR DESCRIPTION
```
const config = loadConfigSync({
  demo: {
    optionalConfiguration: {variableName: 'OPTIONAL_CONFIGURATION'},
    requiredConfiguration: {
      required: true,
      variableName: 'REQUIRED_CONFIGURATION',
    },
  },
});
// Type is `?string`.
config.demo.optionalConfiguration;
// Type is `string`.
config.demo.requiredConfiguration;
```