### PR TITLE
Include erroring properties in error message.

### DIFF
--- a/__tests__/load-config-sync.test.ts
+++ b/__tests__/load-config-sync.test.ts
@@ -439,11 +439,13 @@ describe('loadConfig', () => {
     const filePath = '/path/file.extension';
     const variableName = 'VARIABLE_NAME';
 
-    it('stringifies to include all messages.', () => {
+    beforeEach(() => {
       delete process.env[variableName];
       // @ts-ignore
       fs._setFiles({});
+    });
 
+    it('stringifies to include all messages.', () => {
       try {
         loadConfigSync({
           fileProperty: {
@@ -457,6 +459,24 @@ describe('loadConfig', () => {
         const errorMessage = JSON.stringify(error);
         expect(errorMessage).toMatch('File not found.');
         expect(errorMessage).toMatch('VARIABLE_NAME is not defined.');
+      }
+    });
+
+    it('includes unloaded properties in the message.', () => {
+      try {
+        loadConfigSync({
+          fileProperty: {
+            filePath,
+          },
+          variableProperty: {
+            variableName,
+          },
+        });
+      } catch (error) {
+        expect(error.message).toMatch('fileProperty: File not found.');
+        expect(error.message).toMatch(
+          'variableProperty: VARIABLE_NAME is not defined.',
+        );
       }
     });
   });

--- a/__tests__/load-config.test.ts
+++ b/__tests__/load-config.test.ts
@@ -460,4 +460,22 @@ describe('loading errors', () => {
       expect(errorMessage).toMatch('VARIABLE_NAME is not defined.');
     }
   });
+
+  it('includes unloaded properties in the message.', async () => {
+    try {
+      await loadConfig({
+        fileProperty: {
+          filePath,
+        },
+        variableProperty: {
+          variableName,
+        },
+      });
+    } catch (error) {
+      expect(error.message).toMatch('fileProperty: File not found.');
+      expect(error.message).toMatch(
+        'variableProperty: VARIABLE_NAME is not defined.',
+      );
+    }
+  });
 });

--- a/src/config-error.ts
+++ b/src/config-error.ts
@@ -14,7 +14,14 @@ export default class ConfigError<
    * @param errors - The errors that this ConfigError represent.
    */
   public constructor(errors: ErrorMap) {
-    super('Configuration could not be loaded.');
+    super(
+      [
+        'Configuration could not be loaded for the following properties:',
+        ...Object.entries(errors).map(
+          ([key, {message}]) => `${key}: ${message}`,
+        ),
+      ].join('\n\t'),
+    );
     this.errors = errors;
   }
 


### PR DESCRIPTION
I'm really tired of getting `Configuration could not be loaded.` and then trying to figure it out.  I really should have done this earlier.