### PR TITLE
Use `@ts-expect-error`.

### DIFF
--- a/__tests__/load-config-sync.test.ts
+++ b/__tests__/load-config-sync.test.ts
@@ -12,7 +12,7 @@ describe('loadConfig', () => {
 
   describe('invariants', () => {
     it('throws if a property config of "configMap" has neither "filePath" nor "variableName".', () => {
-      // @ts-ignore
+      // @ts-expect-error
       expect(() => loadConfigSync({property: {}})).toThrow(
         '"configMap.property" must be a string, EnvironmentConfig object, or FileConfig object.  Neither "filePath" nor "variableName" are defined.',
       );
@@ -210,7 +210,7 @@ describe('loadConfig', () => {
       const fileContent = 'The content of this file.';
 
       it('equals the file content decoded as UTF-8 if no encoding is defined.', () => {
-        // @ts-ignore
+        // @ts-expect-error-ignore
         fs._setFiles({[filePath]: Buffer.from(fileContent, 'utf8')});
 
         const config = loadConfigSync({
@@ -222,7 +222,7 @@ describe('loadConfig', () => {
       });
 
       it('equals the file content decoded using the given encoding, if defined.', () => {
-        // @ts-ignore
+        // @ts-expect-error-ignore
         fs._setFiles({[filePath]: Buffer.from(fileContent, 'ascii')});
 
         const config = loadConfigSync({
@@ -235,7 +235,7 @@ describe('loadConfig', () => {
       });
 
       it('does not use the default value.', () => {
-        // @ts-ignore
+        // @ts-expect-error-ignore
         fs._setFiles({[filePath]: Buffer.from(fileContent, 'utf8')});
 
         const defaultValue = 'SOMETHING_ELSE';
@@ -250,7 +250,7 @@ describe('loadConfig', () => {
       });
 
       it('is passed to the formatter.', () => {
-        // @ts-ignore
+        // @ts-expect-error-ignore
         fs._setFiles({[filePath]: Buffer.from(fileContent, 'utf8')});
 
         const formatter = jest.fn();
@@ -266,7 +266,7 @@ describe('loadConfig', () => {
 
     describe('when the file is not present', () => {
       beforeEach(() => {
-        // @ts-ignore
+        // @ts-expect-error-ignore
         fs._setFiles({});
       });
 
@@ -378,7 +378,7 @@ describe('loadConfig', () => {
 
     beforeEach(() => {
       process.env[variableName] = variableValue;
-      // @ts-ignore
+      // @ts-expect-error-ignore
       fs._setFiles({[filePath]: Buffer.from(fileContent, 'utf8')});
     });
 
@@ -481,7 +481,7 @@ describe('loadConfig', () => {
 
     beforeEach(() => {
       delete process.env[variableName];
-      // @ts-ignore
+      // @ts-expect-error-ignore
       fs._setFiles({});
     });
 

--- a/__tests__/load-config.test.ts
+++ b/__tests__/load-config.test.ts
@@ -12,7 +12,7 @@ describe('loadConfig', () => {
 
   describe('invariants', () => {
     it('rejects if a property config of "configMap" has neither "filePath" nor "variableName".', async () => {
-      // @ts-ignore
+      // @ts-expect-error-ignore
       await expect(loadConfig({property: {}})).rejects.toThrow(
         '"configMap.property" must be a string, EnvironmentConfig object, or FileConfig object.  Neither "filePath" nor "variableName" are defined.',
       );
@@ -210,7 +210,7 @@ describe('loadConfig', () => {
       const fileContent = 'The content of this file.';
 
       it('equals the file content decoded as UTF-8 if no encoding is defined.', async () => {
-        // @ts-ignore
+        // @ts-expect-error-ignore
         fs._setFiles({[filePath]: Buffer.from(fileContent, 'utf8')});
 
         const config = await loadConfig({
@@ -222,7 +222,7 @@ describe('loadConfig', () => {
       });
 
       it('equals the file content decoded using the given encoding, if defined.', async () => {
-        // @ts-ignore
+        // @ts-expect-error-ignore
         fs._setFiles({[filePath]: Buffer.from(fileContent, 'ascii')});
 
         const config = await loadConfig({
@@ -235,7 +235,7 @@ describe('loadConfig', () => {
       });
 
       it('does not use the default value.', async () => {
-        // @ts-ignore
+        // @ts-expect-error-ignore
         fs._setFiles({[filePath]: Buffer.from(fileContent, 'utf8')});
 
         const defaultValue = 'SOMETHING_ELSE';
@@ -250,7 +250,7 @@ describe('loadConfig', () => {
       });
 
       it('is passed to the formatter.', async () => {
-        // @ts-ignore
+        // @ts-expect-error-ignore
         fs._setFiles({[filePath]: Buffer.from(fileContent, 'utf8')});
 
         const formatter = jest.fn();
@@ -266,7 +266,7 @@ describe('loadConfig', () => {
 
     describe('when the file is not present', () => {
       beforeEach(() => {
-        // @ts-ignore
+        // @ts-expect-error-ignore
         fs._setFiles({});
       });
 
@@ -378,7 +378,7 @@ describe('loadConfig', () => {
 
     beforeEach(() => {
       process.env[variableName] = variableValue;
-      // @ts-ignore
+      // @ts-expect-error-ignore
       fs._setFiles({[filePath]: Buffer.from(fileContent, 'utf8')});
     });
 
@@ -482,7 +482,7 @@ describe('loading errors', () => {
 
   it('stringifies to include all messages.', async () => {
     delete process.env[variableName];
-    // @ts-ignore
+    // @ts-expect-error-ignore
     fs._setFiles({});
 
     try {

--- a/source/format-property.ts
+++ b/source/format-property.ts
@@ -11,7 +11,7 @@ function tryToFormat<Value>(
   }
 }
 
-export default function something<Value>(
+export default function formatProperty<Value>(
   propertyResult: PropertyResult<string>,
   propertyConfig: BaseConfig<Value>,
 ): PropertyResult<string | Value> {


### PR DESCRIPTION
This has been around since 3.9, I'm not sure why I wasn't using it.