### PR TITLE
Bump `eslint-plugin-unicorn`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "builtin-modules": "^3.2.0",
     "eslint": "^8.4.1",
     "eslint-plugin-eslint-comments": "^3.2.0",
-    "eslint-plugin-unicorn": "^40.0.0",
+    "eslint-plugin-unicorn": "^41.0.0",
     "jest": "^27.0.6",
     "map-to-map": "^2.0.0",
     "prettier": "2.5.1",

--- a/source/types.ts
+++ b/source/types.ts
@@ -33,6 +33,7 @@ export interface EnvironmentConfig<Value> extends BaseConfig<Value> {
  * Configuration for a property loaded from a secret.
  */
 export interface FileConfig<Value> extends BaseConfig<Value> {
+  /* eslint-disable unicorn/text-encoding-identifier-case  -- Values that would upset this rule are still valid. */
   /**
    * The encoding of the file containing the secret.
    * @defaultValue 'utf8'
@@ -49,6 +50,7 @@ export interface FileConfig<Value> extends BaseConfig<Value> {
     | 'latin1'
     | 'binary'
     | 'hex';
+  /* eslint-enable unicorn/text-encoding-identifier-case */
 
   /**
    * The path to the file containing the secret.


### PR DESCRIPTION
Couldn't be done automatically since it required an `eslint-disable` for a type.