### PR TITLE
Update required `node` version.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 jobs:
   lint:
     docker:
-      - image: circleci/node:12
+      - image: circleci/node:14
     steps:
       - checkout
       - restore_cache:
@@ -18,7 +18,7 @@ jobs:
 
   release:
     docker:
-      - image: circleci/node:12
+      - image: circleci/node:14
     steps:
       - checkout
       - restore_cache:
@@ -31,11 +31,11 @@ jobs:
             - node_modules
           key: v1-dependencies-{{ checksum "package.json" }}
       - run: yarn build
-      - run: npx semantic-release@17
+      - run: npx semantic-release
 
   test:
     docker:
-      - image: circleci/node:12
+      - image: circleci/node:14
     steps:
       - checkout
       - restore_cache:
@@ -52,7 +52,7 @@ jobs:
 
   test-distribution:
     docker:
-      - image: circleci/node:12
+      - image: circleci/node:14
     steps:
       - checkout
       - restore_cache:

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -45,7 +45,7 @@ module.exports = {
       },
     },
     {
-      files: ['__mocks__/*.ts', 'scripts/jest/*.js', '.eslintrc.js'],
+      files: ['__mocks__/**/*.ts', 'scripts/jest/*.js', '.eslintrc.js'],
       rules: {
         // Mocks and some configuration files cannot be modules.
         'unicorn/prefer-module': 'off',

--- a/__mocks__/fs/promises.ts
+++ b/__mocks__/fs/promises.ts
@@ -6,7 +6,7 @@ function _setFiles(newFiles: {[path: string]: Buffer}): void {
   files = mapToMap(newFiles);
 }
 
-const readFileSync = jest.fn((path: string, encoding: BufferEncoding) => {
+const readFile = jest.fn(async (path: string, encoding: BufferEncoding) => {
   const file = files.get(path);
   if (file && Buffer.isBuffer(file)) {
     return file.toString(encoding);
@@ -16,5 +16,5 @@ const readFileSync = jest.fn((path: string, encoding: BufferEncoding) => {
 
 module.exports = {
   _setFiles,
-  readFileSync,
+  readFile,
 };

--- a/__tests__/load-config.test.ts
+++ b/__tests__/load-config.test.ts
@@ -1,6 +1,6 @@
-jest.mock('fs');
+jest.mock('fs/promises');
 
-import fs from 'fs';
+import fs from 'fs/promises';
 import {ConfigError, loadConfig} from '../source';
 
 describe('loadConfig', () => {

--- a/package.json
+++ b/package.json
@@ -10,13 +10,12 @@
     "@babel/core": "^7.15.0",
     "@babel/preset-env": "^7.15.0",
     "@babel/preset-typescript": "^7.15.0",
-    "@commitlint/cli": "^16.0.0",
-    "@commitlint/config-conventional": "^16.0.0",
+    "@commitlint/cli": "^17.0.1",
+    "@commitlint/config-conventional": "^17.0.0",
     "@rushstack/eslint-config": "^2.5.0",
     "@types/jest": "^27.4.1",
     "@types/node": "^16.6.1",
     "babel-jest": "^28.0.2",
-    "builtin-modules": "^3.2.0",
     "eslint": "^8.4.1",
     "eslint-plugin-eslint-comments": "^3.2.0",
     "eslint-plugin-unicorn": "^42.0.0",
@@ -25,11 +24,11 @@
     "prettier": "2.6.2",
     "rimraf": "^3.0.2",
     "rollup": "^2.56.0",
-    "rollup-plugin-ts": "^2.0.0",
-    "typescript": "~4.6.0"
+    "rollup-plugin-ts": "^3.0.1",
+    "typescript": "~4.7.2"
   },
   "engines": {
-    "node": ">=12"
+    "node": ">=14"
   },
   "files": [
     "distribution",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,4 +1,4 @@
-import builtinModules from 'builtin-modules';
+import {builtinModules} from 'module';
 import ts from 'rollup-plugin-ts';
 import {fileURLToPath} from 'url';
 import packageJson from './package.json';

--- a/source/load-file-property.ts
+++ b/source/load-file-property.ts
@@ -1,14 +1,20 @@
-import {readFile} from 'fs';
+import {readFile} from 'fs/promises';
 import formatProperty from './format-property';
 import {FileConfig, PropertyResult} from './types';
 
-export default function loadFileProperty<Value>(
+async function tryToReadFile(
+  propertyConfig: FileConfig<unknown>,
+): Promise<PropertyResult<string>> {
+  const {encoding = 'utf8', filePath} = propertyConfig;
+  try {
+    return {error: false, value: await readFile(filePath, encoding)};
+  } catch (error) {
+    return {error: error as Error, value: undefined};
+  }
+}
+
+export default async function loadFileProperty<Value>(
   propertyConfig: FileConfig<Value>,
 ): Promise<PropertyResult<string | Value>> {
-  const {encoding = 'utf8', filePath} = propertyConfig;
-  return new Promise((resolve) => {
-    readFile(filePath, encoding, (error, value) => {
-      resolve(formatProperty({error: error ?? false, value}, propertyConfig));
-    });
-  });
+  return formatProperty(await tryToReadFile(propertyConfig), propertyConfig);
 }


### PR DESCRIPTION
Drops `node@12`.  Starts using `fs/promises`.