### PR TITLE
Clean up some types.

### DIFF
--- a/source/config-error.ts
+++ b/source/config-error.ts
@@ -32,11 +32,14 @@ export default class ConfigError<
    * This is here so the ConfigError can be stringified a little cleaner.  Throwing it'll still just show the base message.
    * @returns An object containing the message of this error and the messages of the errors it represents.
    */
-  public toJSON(): {errors: {[name: string]: string}; message: string} {
+  public toJSON(): {
+    errors: {[key in keyof ErrorMap]: string};
+    message: string;
+  } {
     return {
       errors: Object.fromEntries(
         Object.entries(this.errors).map(([key, {message}]) => [key, message]),
-      ),
+      ) as {[key in keyof ErrorMap]: string},
       message: this.message,
     };
   }

--- a/source/format-property.ts
+++ b/source/format-property.ts
@@ -26,9 +26,6 @@ export default function formatProperty<Value>(
   }
 
   return hasValue && hasFormat
-    ? tryToFormat(
-        propertyResult.value as string,
-        format as PropertyFormatter<Value>,
-      )
+    ? tryToFormat(propertyResult.value as string, format)
     : {error: false, value: defaultValue};
 }

--- a/source/load-config-sync.ts
+++ b/source/load-config-sync.ts
@@ -1,6 +1,6 @@
 import ConfigError from './config-error';
 import loadPropertySync from './load-property-sync';
-import {PropertyConfig, UnwrapPropertyConfig} from './types';
+import {PropertyConfig, UnwrapConfigMap, UnwrapPropertyConfig} from './types';
 
 /**
  * Load configuration synchronously.
@@ -38,18 +38,14 @@ export default function loadConfigSync<
   configMap: ConfigMap,
 ): {[key in keyof ConfigMap]: UnwrapPropertyConfig<ConfigMap[key]>} {
   const errorMap = new Map<string, Error>();
-  const result = {} as {
-    [key in keyof ConfigMap]: UnwrapPropertyConfig<ConfigMap[key]>;
-  };
-  for (const [propertyName, propertyConfig] of Object.entries(configMap) as [
-    string & keyof ConfigMap,
-    ConfigMap[keyof ConfigMap],
-  ][]) {
+  const result = {} as UnwrapConfigMap<ConfigMap>;
+  for (const [propertyName, propertyConfig] of Object.entries(configMap)) {
     const {error, value} = loadPropertySync(propertyConfig, propertyName);
     if (error !== false) {
       errorMap.set(propertyName, error);
     }
-    result[propertyName] = value as UnwrapPropertyConfig<
+
+    result[propertyName as keyof ConfigMap] = value as UnwrapPropertyConfig<
       ConfigMap[keyof ConfigMap]
     >;
   }

--- a/source/load-config.ts
+++ b/source/load-config.ts
@@ -42,7 +42,7 @@ export default async function loadConfig<
     Object.entries(configMap).map(async ([propertyName, propertyConfig]) => {
       const {error, value} = await loadProperty(propertyConfig, propertyName);
       if (error !== false) {
-        errorMap.set(propertyName as string, error);
+        errorMap.set(propertyName, error);
       }
 
       return [propertyName, value];

--- a/source/load-environment-property.ts
+++ b/source/load-environment-property.ts
@@ -9,7 +9,7 @@ export default function loadEnvironmentProperty<Value>(
   return formatProperty(
     {
       error:
-        typeof value !== 'string' &&
+        typeof value === 'undefined' &&
         new Error(`${variableName} is not defined.`),
       value,
     },

--- a/source/types.ts
+++ b/source/types.ts
@@ -107,14 +107,8 @@ export type UnwrapConfigMap<
  * Unwrap a property config to its resultant value.
  */
 export type UnwrapPropertyConfig<PConfig extends PropertyConfig<unknown>> =
-  PConfig extends string
-    ? string
-    : PConfig extends {required: false}
-    ? UnwrapResult<PConfig> | undefined
-    : UnwrapResult<PConfig>;
-
-/**
- * Unwrap a result to its value.
- */
-type UnwrapResult<PConfig extends PropertyConfig<unknown>> =
-  PConfig extends BaseConfig<infer Value> ? Value : string;
+  PConfig extends BaseConfig<infer Value>
+    ? PConfig extends {required: false}
+      ? Value | undefined
+      : Value
+    : string;


### PR DESCRIPTION
Should still work with `typescript@4.6.0`.