### PR TITLE
Update dependencies.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -49,6 +49,7 @@ module.exports = {
       rules: {
         // Mocks and some configuration files cannot be modules.
         'unicorn/prefer-module': 'off',
+        'unicorn/prefer-top-level-await': 'off',
       },
     },
   ],
@@ -61,6 +62,8 @@ module.exports = {
     'unicorn/import-style': 'off',
     // Since this is covered by 'eslint-comments/no-unlimited-disable'.
     'unicorn/no-abusive-eslint-disable': 'off',
+    // The idea is that other development-time checks would tell you if you're referencing an undefined variable, so it won't run if you access it for this comparison.  But I'd rather just avoid that risk altogether.
+    'unicorn/no-typeof-undefined': 'off',
     'unicorn/no-unsafe-regex': 'error',
     // Does not work with TypeScript and is not backported to all supported versions of Node.
     'unicorn/prefer-node-protocol': 'off',

--- a/package.json
+++ b/package.json
@@ -18,12 +18,12 @@
     "babel-jest": "^29.0.0",
     "eslint": "^8.21.0",
     "eslint-plugin-eslint-comments": "^3.2.0",
-    "eslint-plugin-unicorn": "^44.0.0",
+    "eslint-plugin-unicorn": "^45.0.1",
     "jest": "^29.0.0",
     "map-to-map": "^2.0.0",
     "prettier": "2.8.1",
     "rimraf": "^3.0.2",
-    "rollup": "^2.56.0",
+    "rollup": "^3.7.2",
     "rollup-plugin-ts": "^3.0.1",
     "typescript": "~4.9.0"
   },
@@ -54,7 +54,7 @@
   "name": "env-and-files",
   "repository": "wtgtybhertgeghgtwtg/env-and-files",
   "scripts": {
-    "build": "rollup -c",
+    "build": "rollup --bundleConfigAsCjs --config ./rollup.config.js",
     "clean": "rimraf coverage distribution",
     "lint": "tsc && eslint . && prettier --l \"{__mocks__,__tests__,source}/**/*.ts\"",
     "test": "yarn test:source && yarn build && yarn test:distribution",


### PR DESCRIPTION
The build script is now giving warnings because `rollup-plugin-ts` uses some deprecated functions of `typescript`.  Will have to change it for something else soon.