### PR TITLE
Pin `semantic-release`.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
             - node_modules
           key: v1-dependencies-{{ checksum "package.json" }}
       - run: yarn build
-      - run: npx semantic-release
+      - run: npx semantic-release@19.0.5
 
   test:
     docker:


### PR DESCRIPTION
This has happened before.  I really shouldn't unpin it again.